### PR TITLE
CO-3528 add analytic tag to be used by default for exchange rate diff

### DIFF
--- a/account_analytic_compassion/__manifest__.py
+++ b/account_analytic_compassion/__manifest__.py
@@ -42,6 +42,7 @@
     ],
     'data': [
         'views/product_view.xml',
+        'views/res_config_setting_view.xml',
         'views/account_asset_view.xml',
     ],
     'demo': ['analytic_account_data.xml'],

--- a/account_analytic_compassion/models/__init__.py
+++ b/account_analytic_compassion/models/__init__.py
@@ -9,4 +9,6 @@
 
 from . import account
 from . import account_asset
+from . import res_config_setting
+from . import exchange_rate_analytic_tag
 from . import product

--- a/account_analytic_compassion/models/exchange_rate_analytic_tag.py
+++ b/account_analytic_compassion/models/exchange_rate_analytic_tag.py
@@ -1,0 +1,21 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    @author: David Wulliamoz <dwulliamoz@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import models, fields, api
+
+class AccountPartialReconcile(models.Model):
+    _inherit = "account.partial.reconcile"
+
+    @api.model
+    def create_exchange_rate_entry(self, aml_to_fix, move):
+        exchange_analytic_tag_id = self.env['ir.config_parameter'].\
+            search([('key', '=', 'account_analytic_compassion.analytic_tag_id')]).value
+        return super(AccountPartialReconcile, self.with_context(
+            default_analytic_tag_ids=[
+                (6, 0, [exchange_analytic_tag_id])
+            ])).create_exchange_rate_entry( aml_to_fix, move)

--- a/account_analytic_compassion/models/res_config_setting.py
+++ b/account_analytic_compassion/models/res_config_setting.py
@@ -1,0 +1,28 @@
+from odoo import api, fields, models, _
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    analytic_tag_id = fields.Many2one('account.analytic.tag', string='Analytic Tag',
+                                      readonly=False, help="analytic tag id to use "
+                                      "when automatic move are created."
+                                      )
+    @api.multi
+    def set_values(self):
+        super().set_values()
+        self.env["ir.config_parameter"].sudo().set_param(
+            "account_analytic_compassion.analytic_tag_id",
+            str(self.analytic_tag_id.id),
+        )
+
+    @api.model
+    def get_values(self):
+        res = super().get_values()
+        param_obj = self.env["ir.config_parameter"].sudo()
+        res["analytic_tag_id"] = int(
+            param_obj.get_param(
+                "account_analytic_compassion.analytic_tag_id"
+            )
+        )
+        return res

--- a/account_analytic_compassion/views/res_config_setting_view.xml
+++ b/account_analytic_compassion/views/res_config_setting_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- inherited from account-financial-tools/account_asset_management/views/account_asset.xml -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.account</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <field name="currency_exchange_journal_id" position="after">
+            <label for="analytic_tag_id"/><field name="analytic_tag_id"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
CO-3528
Add analytic tag in settings and allow to be set by default when exchange diff is created.

the display layout in the setting is not good, if there is a proposal to do better...