### PR TITLE
Clear invoices

### DIFF
--- a/recurring_contract/models/invoice.py
+++ b/recurring_contract/models/invoice.py
@@ -19,6 +19,8 @@ class AccountInvoice(models.Model):
     recurring_invoicer_id = fields.Many2one(
         'recurring.invoicer', 'Invoicer', readonly=False)
 
+    invoice_category = fields.Selection()
+
     @api.multi
     def action_invoice_paid(self):
         """ Call invoice_paid method on related contracts. """


### PR DESCRIPTION
- code refactoring
   - Add new function to compute invoices to clean on payment method change
   - Change `_clean_invoice` to keep line when parameter is set only  
- Add category filter
   - Add `ignore_categories` parameters to avoid cleaning a non sponsorship invoices or mistaking an invoice for an other one 
