### PR TITLE
Refactor contract clean

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -268,7 +268,7 @@ class ContractGroup(models.Model):
             if group.next_invoice_date and group.next_invoice_date < since_date:
                 group._generate_invoices()
 
-            res |= group.contract_ids.with_context(async_mode=False, called_from_group=True).rewind_next_invoice_date()
+            res |= group.contract_ids.with_context(async_mode=False).rewind_next_invoice_date()
         # Generate again invoices
         self._generate_invoices(invoicer=None, cancelled_invoices=res.filtered(
             lambda inv: inv.state == "cancel" and inv.date_invoice >= since_date

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -268,7 +268,7 @@ class ContractGroup(models.Model):
             if group.next_invoice_date and group.next_invoice_date < since_date:
                 group._generate_invoices()
 
-            res |= group.contract_ids.with_context(async_mode=False).rewind_next_invoice_date()
+            res |= group.contract_ids.with_context(async_mode=False, called_from_group=True).rewind_next_invoice_date()
         # Generate again invoices
         self._generate_invoices(invoicer=None, cancelled_invoices=res.filtered(
             lambda inv: inv.state == "cancel" and inv.date_invoice >= since_date
@@ -307,7 +307,7 @@ class ContractGroup(models.Model):
             'payment_term_id': self.env.ref(
                 'account.account_payment_term_immediate').id,
             'currency_id':
-            partner.property_product_pricelist.currency_id.id,
+                partner.property_product_pricelist.currency_id.id,
             'date_invoice': self.next_invoice_date,
             'recurring_invoicer_id': invoicer.id,
             'payment_mode_id': self.payment_mode_id.id,

--- a/recurring_contract/models/invoice.py
+++ b/recurring_contract/models/invoice.py
@@ -46,6 +46,9 @@ class AccountInvoice(models.Model):
             - amount for reconciling the future invoices
             - leftover amount that will stay in the client balance
         Then the invoices will be reconciled again
+
+        Invoices should be opened or canceled. if they are canceled they will
+        first be reopened
         :return: True
         """
         # At first we open again the cancelled invoices

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -493,7 +493,7 @@ class RecurringContract(models.Model):
             if invoice not in empty_invoices:
                 remaining_lines = invoice.invoice_line_ids.filtered(
                     lambda l: not l.contract_id or l.contract_id not in self)
-                if remaining_lines and not self.env.context.get("called_from_group", False):
+                if remaining_lines:
                     # We can move or remove the line
                     to_remove_invl |= inv_line
                 else:

--- a/recurring_contract/tests/test_recurring_contract.py
+++ b/recurring_contract/tests/test_recurring_contract.py
@@ -440,3 +440,122 @@ class TestContractCompassion(BaseContractCompassionTest):
         contract.on_change_group_id()
         self.assertEqual(
             contract.group_id.payment_mode_id, payment_mode_2)
+
+    def test_change_contract_group(self):
+        """
+            Test correct behavior on contract_group change.
+            when change method is set to clean invoices changing the advance billing month
+            should regenerate the invoices for this contract.
+        """
+        contract_group = self.create_group(
+            {
+                "partner_id": self.michel.id,
+                "change_method": "clean_invoices"
+            }
+        )
+        contract = self.create_contract(
+            {
+                "partner_id": self.michel.id,
+                "group_id": contract_group.id,
+            },
+            [{"amount": 50.0}])
+
+        total_amount = contract.total_amount
+
+        contract.contract_waiting()
+        invoices = contract.button_generate_invoices().invoice_ids
+
+        self.assertEqual(len(invoices), 2)
+
+        contract_group.with_context(async_mode=False).write(
+            {"advance_billing_months": 3})
+
+        self.assertEqual(len(contract.invoice_line_ids.mapped("invoice_id")), 4)
+        for inv in contract.invoice_line_ids.mapped("invoice_id"):
+            self.assertEqual(total_amount, inv.amount_untaxed)
+
+    def test_keep_paid_invoice_on_group_change(self):
+        contract_group = self.create_group(
+            {
+                "partner_id": self.michel.id,
+                "change_method": "clean_invoices",
+                "advance_billing_months": 3
+            }
+        )
+        contract = self.create_contract(
+            {
+                "partner_id": self.michel.id,
+                "group_id": contract_group.id,
+            },
+            [{"amount": 50.0}])
+
+        contract.contract_waiting()
+
+        invoices = contract.button_generate_invoices().invoice_ids
+
+        self.assertEqual(len(invoices), 4)
+
+        # ensure we pay the most recent invoice
+        invoice_to_pay = self.env["account.invoice"].search([("id", "in", invoices.ids)], order="date_invoice desc",
+                                                            limit=1)
+        self._pay_invoice(invoice_to_pay)
+        self.assertEqual(invoice_to_pay.state, "paid")
+
+        # changing advance billing to one month
+        # 2 month are now obsolete but one is paid
+        # so 1 invoice cancel and 1 invoice paid
+        contract_group.with_context(async_mode=False).write({
+            "advance_billing_months": 1
+        })
+
+        invoices = contract.invoice_line_ids.mapped("invoice_id")
+
+        # number of invoices should remain the same
+        self.assertEqual(len(invoices), 4)
+
+        # 1 invoice should still be paid
+        self.assertEqual(len(invoices.filtered(lambda x: x.state == "paid")), 1)
+
+        # 2 invoices should be open
+        self.assertEqual(len(invoices.filtered(lambda x: x.state == "open")), 2)
+
+        # 1 invoice should be canceled
+        self.assertEqual(len(invoices.filtered(lambda x: x.state == "cancel")), 1)
+
+    def _test_invoice_generation_behavior_on_new_contract_in_group(self):
+        """When a new contract is added to a contract group invoices should be merged"""
+
+        contract_group = self.create_group(
+            {
+                "partner_id": self.michel.id,
+                "change_method": "clean_invoices",
+                "advance_billing_months": 1
+            }
+        )
+        contract = self.create_contract(
+            {
+                "partner_id": self.michel.id,
+                "group_id": contract_group.id,
+            },
+            [{"amount": 50.0}])
+
+        contract.contract_waiting()
+        invoices = contract.button_generate_invoices().invoice_ids
+
+        self.assertEqual(len(invoices), 2)
+
+        self._pay_invoice(invoices[-1])
+
+        self.assertEqual(invoices[-1].state, "paid")
+
+        contract2 = self.create_contract(
+            {
+                "partner_id": self.michel.id,
+                "group_id": contract_group.id,
+            },
+            [{"amount": 20.0}])
+
+        contract2.contract_waiting()
+        contract2.button_generate_invoices()
+
+        self.assertEqual(len(contract_group.mapped("contract_ids.invoice_line_ids.invoice_id")), 3)

--- a/recurring_contract/tests/test_recurring_contract.py
+++ b/recurring_contract/tests/test_recurring_contract.py
@@ -495,8 +495,8 @@ class TestContractCompassion(BaseContractCompassionTest):
 
         self.assertEqual(len(invoices), 4)
 
-        # ensure we pay the most recent invoice
-        invoice_to_pay = self.env["account.invoice"].search([("id", "in", invoices.ids)], order="date_invoice desc",
+        # ensure we pay the most earliest invoice
+        invoice_to_pay = self.env["account.invoice"].search([("id", "in", invoices.ids)], order="date_invoice asc",
                                                             limit=1)
         self._pay_invoice(invoice_to_pay)
         self.assertEqual(invoice_to_pay.state, "paid")
@@ -517,10 +517,10 @@ class TestContractCompassion(BaseContractCompassionTest):
         self.assertEqual(len(invoices.filtered(lambda x: x.state == "paid")), 1)
 
         # 2 invoices should be open
-        self.assertEqual(len(invoices.filtered(lambda x: x.state == "open")), 2)
+        self.assertEqual(len(invoices.filtered(lambda x: x.state == "open")), 1)
 
         # 1 invoice should be canceled
-        self.assertEqual(len(invoices.filtered(lambda x: x.state == "cancel")), 1)
+        self.assertEqual(len(invoices.filtered(lambda x: x.state == "cancel")), 2)
 
     def _test_invoice_generation_behavior_on_new_contract_in_group(self):
         """When a new contract is added to a contract group invoices should be merged"""
@@ -559,3 +559,38 @@ class TestContractCompassion(BaseContractCompassionTest):
         contract2.button_generate_invoices()
 
         self.assertEqual(len(contract_group.mapped("contract_ids.invoice_line_ids.invoice_id")), 3)
+
+    def test_multiple_paid_in_clean_range(self):
+        """assess good behavior if we found multiple paid invoices in the month to come and we do a clean"""
+
+        contract_group = self.create_group(
+            {
+                "partner_id": self.michel.id,
+                "change_method": "clean_invoices",
+                "advance_billing_months": 3
+            }
+        )
+        contract = self.create_contract(
+            {
+                "partner_id": self.michel.id,
+                "group_id": contract_group.id,
+            },
+            [{"amount": 50.0}])
+
+        contract.contract_waiting()
+        invoices = contract.button_generate_invoices().invoice_ids
+
+        sorted_invoices = sorted(invoices, key=lambda e: e.date)
+
+        self.assertEqual(len(sorted_invoices), 4)
+
+        for inv in sorted_invoices[:3]:
+            self._pay_invoice(inv)
+            self.assertEqual(inv.state, "paid")
+
+        contract_group.clean_invoices()
+
+        all_contract_invoice = self.env["account.invoice.line"].search([("contract_id", "=", contract.id)]).mapped(
+            "invoice_id")
+
+        self.assertEqual(len(all_contract_invoice), 4)


### PR DESCRIPTION
- does not cancel paid invoice on clean by default
- add context value to prevent automatic cleaning on next_invoice_date change if needed
- improve invoice generation to reopen newly cancelled invoices rather than creating new ones
- add test to assess good behavior