### PR TITLE
CO-3616 FIX reconcile clean

### DIFF
--- a/recurring_contract/__manifest__.py
+++ b/recurring_contract/__manifest__.py
@@ -29,10 +29,10 @@
 {
     'name': 'Recurring contract',
     'summary': 'Contract for recurring invoicing',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'Compassion CH',
-    'development_status': 'Stable',
+    'development_status': 'Production/Stable',
     'website': 'http://www.compassion.ch',
     'category': 'Accounting',
     'depends': [

--- a/recurring_contract/models/__init__.py
+++ b/recurring_contract/models/__init__.py
@@ -6,3 +6,4 @@ from . import recurring_contract_line
 from . import queue_job
 from . import utm
 from . import end_reason
+from . import move_line

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -218,7 +218,8 @@ class ContractGroup(models.Model):
                 if not contracts:
                     break
                 try:
-                    inv_to_reopen = cancelled_invoices.filtered(lambda inv: inv.date_invoice == current_date)
+                    inv_to_reopen = cancelled_invoices.filtered(
+                        lambda inv: inv.date_invoice == current_date)
 
                     inv_data = contract_group._setup_inv_data(
                         journal, invoicer, contracts)
@@ -260,20 +261,20 @@ class ContractGroup(models.Model):
         contract group.
         """
         res = self.env['account.invoice']
-        since_date = date.today()
         for group in self:
 
-            # invoice for current contract might not be up to date. since we are changing the value of next_invoice_date
+            # invoice for current contract might not be up to date.
+            # since we are changing the value of next_invoice_date
             # this might cause some issue if we don't first generate the missing one.
-            if group.next_invoice_date and group.next_invoice_date < since_date:
+            if group.next_invoice_date and group.next_invoice_date <= date.today():
                 group._generate_invoices()
 
-            res |= group.contract_ids.with_context(async_mode=False).rewind_next_invoice_date()
+            res |= group.contract_ids.with_context(
+                async_mode=False).rewind_next_invoice_date()
         # Generate again invoices
         self._generate_invoices(invoicer=None, cancelled_invoices=res.filtered(
-            lambda inv: inv.state == "cancel" and inv.date_invoice >= since_date
+            lambda inv: inv.state == "cancel"
         ))
-
         return res
 
     @api.multi

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -149,7 +149,8 @@ class ContractGroup(models.Model):
             delay = datetime.today()
             if jobs:
                 delay += relativedelta(minutes=1)
-            self.with_delay(eta=delay)._generate_invoices(invoicer, cancelled_invoices=cancelled_invoices)
+            self.with_delay(eta=delay)._generate_invoices(
+                invoicer, cancelled_invoices=cancelled_invoices)
         else:
             self._generate_invoices(invoicer, cancelled_invoices=cancelled_invoices)
         return invoicer

--- a/recurring_contract/models/move_line.py
+++ b/recurring_contract/models/move_line.py
@@ -1,0 +1,79 @@
+##############################################################################
+#
+#    Copyright (C) 2014-2018 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import models, exceptions, _
+
+
+class MoveLine(models.Model):
+    """ Adds a method to split a payment into several move_lines
+    in order to reconcile only a partial amount, avoiding doing
+    partial reconciliation. """
+
+    _inherit = "account.move.line"
+
+    def split_payment_and_reconcile(self):
+        sum_credit = sum(self.mapped("credit"))
+        sum_debit = sum(self.mapped("debit"))
+        if sum_credit == sum_debit:
+            # Nothing to do here
+            return self.reconcile()
+
+        # Check in which direction we are reconciling
+        split_column = "credit" if sum_credit > sum_debit else "debit"
+        difference = abs(sum_credit - sum_debit)
+
+        for line in self:
+            if getattr(line, split_column) > difference:
+                # We will split this line
+                move = line.move_id
+                move_line = line
+                break
+        else:
+            raise exceptions.UserError(
+                _(
+                    "This can only be done if one move line can be split "
+                    "to cover the reconcile difference"
+                )
+            )
+
+        # Edit move in order to split payment into two move lines
+        payment = move_line.payment_id
+        if payment:
+            payment_lines = payment.move_line_ids
+            payment.move_line_ids = False
+        move.button_cancel()
+        move.write(
+            {
+                "line_ids": [
+                    (1, move_line.id, {split_column: move_line.credit - difference}),
+                    (
+                        0,
+                        0,
+                        {
+                            split_column: difference,
+                            "name": self.env.context.get(
+                                "residual_comment", move_line.name
+                            ),
+                            "account_id": move_line.account_id.id,
+                            "date": move_line.date,
+                            "date_maturity": move_line.date_maturity,
+                            "journal_id": move_line.journal_id.id,
+                            "partner_id": move_line.partner_id.id,
+                        },
+                    ),
+                ]
+            }
+        )
+        move.post()
+        if payment:
+            payment.move_line_ids = payment_lines
+
+        # Perform the reconciliation
+        return self.reconcile()

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -208,23 +208,25 @@ class RecurringContract(models.Model):
         res = self.env["account.invoice"]
 
         for contract in self:
-            if contract.state in gen_states:
+            if contract.state not in ["terminated", "cancelled"]:
 
-                # if paid invoice exist in range next_invoice should be *after* latest paid invoice
+                # if paid invoice exist in range next_invoice should be *after*
+                # latest paid invoice
                 latest_paid_invoice_date = max(
-                    [line.invoice_id.date_invoice + contract.group_id.get_relative_delta() for
+                    [line.invoice_id.date_invoice +
+                     contract.group_id.get_relative_delta() for
                      line in contract.invoice_line_ids
-                     if line.state == "paid" and
-                     line.invoice_id.date_invoice >= date.today()] or [False])
+                     if line.state == "paid"] or [False])
 
-                # if there is only open invoice we are looking for the oldest one (within the range)
+                # if there is only open invoice we are looking for the
+                # oldest one (within the range)
                 earliest_open_invoice_date = min(
                     [line.invoice_id.date_invoice for
                      line in contract.invoice_line_ids
-                     if line.state == "open" and
-                     line.invoice_id.date_invoice >= date.today()] or [False])
+                     if line.state == "open"] or [False])
 
-                rewind_invoice_date = latest_paid_invoice_date or earliest_open_invoice_date
+                rewind_invoice_date = latest_paid_invoice_date or \
+                        earliest_open_invoice_date
 
                 if rewind_invoice_date:
 

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -150,11 +150,17 @@ class RecurringContract(models.Model):
 
         res = super().write(vals)
 
+        clean_is_done = False
         if "partner_id" in vals:
             self.mapped("group_id").write({"partner_id": vals["partner_id"]})
+            clean_is_done = "clean_invoices" in self.mapped("group_id.change_method")
 
-        if 'contract_line_ids' in vals:
+        if 'contract_line_ids' in vals and not clean_is_done:
             self._on_contract_lines_changed()
+            clean_is_done = True
+
+        if ("group_id" in vals or "partner_id" in vals) and not clean_is_done:
+            self.group_id.clean_invoices()
 
         return res
 

--- a/recurring_contract/tests/test_recurring_contract.py
+++ b/recurring_contract/tests/test_recurring_contract.py
@@ -444,8 +444,8 @@ class TestContractCompassion(BaseContractCompassionTest):
     def test_change_contract_group(self):
         """
             Test correct behavior on contract_group change.
-            when change method is set to clean invoices changing the advance billing month
-            should regenerate the invoices for this contract.
+            when change method is set to clean invoices changing the advance billing
+            month should regenerate the invoices for this contract.
         """
         contract_group = self.create_group(
             {
@@ -496,8 +496,8 @@ class TestContractCompassion(BaseContractCompassionTest):
         self.assertEqual(len(invoices), 4)
 
         # ensure we pay the most earliest invoice
-        invoice_to_pay = self.env["account.invoice"].search([("id", "in", invoices.ids)], order="date_invoice asc",
-                                                            limit=1)
+        invoice_to_pay = self.env["account.invoice"].search([
+            ("id", "in", invoices.ids)], order="date_invoice asc", limit=1)
         self._pay_invoice(invoice_to_pay)
         self.assertEqual(invoice_to_pay.state, "paid")
 
@@ -558,10 +558,12 @@ class TestContractCompassion(BaseContractCompassionTest):
         contract2.contract_waiting()
         contract2.button_generate_invoices()
 
-        self.assertEqual(len(contract_group.mapped("contract_ids.invoice_line_ids.invoice_id")), 3)
+        self.assertEqual(
+            len(contract_group.mapped("contract_ids.invoice_line_ids.invoice_id")), 3)
 
     def test_multiple_paid_in_clean_range(self):
-        """assess good behavior if we found multiple paid invoices in the month to come and we do a clean"""
+        """assess good behavior if we found multiple paid invoices in
+        the month to come and we do a clean"""
 
         contract_group = self.create_group(
             {
@@ -590,7 +592,7 @@ class TestContractCompassion(BaseContractCompassionTest):
 
         contract_group.clean_invoices()
 
-        all_contract_invoice = self.env["account.invoice.line"].search([("contract_id", "=", contract.id)]).mapped(
-            "invoice_id")
+        all_contract_invoice = self.env["account.invoice.line"].search([
+            ("contract_id", "=", contract.id)]).mapped("invoice_id")
 
         self.assertEqual(len(all_contract_invoice), 4)


### PR DESCRIPTION
- It looks like the reconcile after clean method was not working properly when matching payments existed.
- This fixes badly migrated code and optimizes when changes are made in contracts.
- It has also some code moved from sponsorship_compassion.
- Accounting team prefers that all open invoices are changed, even those from the past.

