### PR TITLE
CO-3856 when a product is changed in an invoice, the analytic_tag_ids…

### DIFF
--- a/recurring_contract/models/invoice.py
+++ b/recurring_contract/models/invoice.py
@@ -192,3 +192,14 @@ class AccountInvoiceLine(models.Model):
             lambda l: l.state == filter_state and
             (not lock_date or (l.due_date and l.due_date > lock_date))
         )
+
+    @api.onchange('product_id')
+    def _onchange_product_id(self):
+        # workaround an odoo bug :
+        # could be fixed by applying this change here
+        # - self.analytic_tag_ids = rec.analytic_tag_ids.ids
+        # + self.analytic_tag_ids = rec.analytic_tag_ids
+        # https://github.com/odoo/odoo/blame/12.0/addons/account_analytic_default/models/account_analytic_default.py#L100
+        self.analytic_tag_ids = self.env["account.analytic.tag"]
+        res = super()._onchange_product_id()
+        return res


### PR DESCRIPTION
… (of the invoice.line) should be clean before adding the one related to the new product

workaround a odoo bug