### PR TITLE
FIX: remove default value on ref field

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -49,7 +49,7 @@ class ContractGroup(models.Model):
     partner_id = fields.Many2one(
         'res.partner', 'Partner', required=True,
         ondelete='cascade', tracking=True, readonly=False)
-    ref = fields.Char('Reference', default="/")
+    ref = fields.Char('Reference')
     recurring_unit = fields.Selection([
         ('day', _('Day(s)')),
         ('week', _('Week(s)')),


### PR DESCRIPTION
Related issue : [CP-165](https://compassion-ch.atlassian.net/browse/CP-165)

Unset default value "/" when a new payment option was created

