### PR TITLE
Generate invoice with company value from sponsorship

### DIFF
--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -373,7 +373,10 @@ class RecurringContract(models.Model):
 
     def button_generate_invoices(self):
         """ Immediately generate invoices of the contract group. """
-        return self.mapped('group_id').with_context({"async_mode": False}).generate_invoices()
+        return self.mapped('group_id')\
+            .with_context({"async_mode": False})\
+            .with_company(self.company_id)\
+            .generate_invoices()
 
     def open_invoices(self):
         self.ensure_one()


### PR DESCRIPTION
Related issue: [CP-242](https://compassion-ch.atlassian.net/browse/CP-242)

When generating an invoice for a sponsorship, the company value is set from the user company environment instead of the sponsorship company value. 

The .with_company() function will set the right company in the environment.