### PR TITLE
CP-384 FIX invoice cancellation at contract termination

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -321,7 +321,7 @@ class ContractGroup(models.Model):
             inherit this method.
         """
         self.ensure_one()
-        # we use the first contract because the informations we retrieve has to be shared
+        # we use the first contract because the information we retrieve has to be shared
         # between all the contracts of the list
         contract = self.active_contract_ids[0]
         company_id = contract.company_id.id

--- a/recurring_contract/models/move.py
+++ b/recurring_contract/models/move.py
@@ -92,7 +92,7 @@ class AccountMove(models.Model):
         mvl_obj = self.env['account.move.line']
         for partner in self.mapped('partner_id'):
             invoices = self.filtered(lambda i: i.partner_id == partner)
-            past_invoices = invoices.filtered(lambda i: i.date <= today)
+            past_invoices = invoices.filtered(lambda i: i.invoice_date_due <= today)
             past_lines = past_invoices.mapped('line_ids').filtered("debit")
             past_amount = sum(past_invoices.mapped('amount_total'))
             future_invoices = invoices - past_invoices

--- a/recurring_contract/models/move.py
+++ b/recurring_contract/models/move.py
@@ -84,123 +84,48 @@ class AccountMove(models.Model):
     def reconcile_after_clean(self):
         """
         Called after clean invoices. If invoices can be reconciled
-        with open payment, this will split the payment into three amounts :
-            - amount for reconciling the past invoices
-            - amount for reconciling the future invoices
-            - leftover amount that will stay in the client balance
-        Then the invoices will be reconciled again
-
-        Invoices should be opened or canceled. if they are canceled they will
-        first be reopened
+        with open payment, this will do it.
+        Invoices should be open when called.
         :return: True
         """
-        # At first we open again the cancelled invoices
-        cancel_invoices = self.filtered(lambda i: i.state == 'cancel')
-        cancel_invoices.button_draft()
-        cancel_invoices.action_post()
         today = date.today()
+        mvl_obj = self.env['account.move.line']
         for partner in self.mapped('partner_id'):
             invoices = self.filtered(lambda i: i.partner_id == partner)
-            past_invoices = invoices.filtered(lambda i: i.invoice_date <= today)
-            future_invoices = invoices - past_invoices
+            past_invoices = invoices.filtered(lambda i: i.date <= today)
+            past_lines = past_invoices.mapped('line_ids').filtered("debit")
             past_amount = sum(past_invoices.mapped('amount_total'))
+            future_invoices = invoices - past_invoices
+            future_lines = future_invoices.mapped('line_ids').filtered("debit")
             future_amount = sum(future_invoices.mapped('amount_total'))
-            is_past_reconciled = not past_invoices
-            is_future_reconciled = not future_invoices
 
             # First try to find matching amount payments
-            open_payments = self.env['account.move.line'].search([
+            criterias = [
                 ('partner_id', '=', partner.id),
-                ('account_id.code', '=', '1050'),
+                ('account_id', '=', partner.property_account_receivable_id.id),
                 ('reconciled', '=', False),
+                ("parent_state", "=", "posted")
+            ]
+            open_payments = mvl_obj.search(criterias + [
                 ('credit', 'in', [past_amount, future_amount])
             ])
             for payment in open_payments:
-                if not is_past_reconciled and payment.credit == past_amount:
-                    lines = past_invoices.mapped('line_ids').filtered("debit")
-                    (lines + payment).reconcile()
-                    is_past_reconciled = True
-                elif not is_future_reconciled and payment.credit == future_amount:
-                    lines = future_invoices.mapped('line_ids').filtered("debit")
-                    (lines + payment).reconcile()
-                    is_future_reconciled = True
+                if past_invoices and payment.credit == past_amount:
+                    (past_lines + payment).reconcile()
+                    past_invoices = past_invoices.filtered(lambda i: i.payment_state != "paid")
+                    future_invoices = future_invoices.filtered(lambda i: i.payment_state != "paid")
+                    future_amount = sum(future_invoices.mapped('amount_total'))
+                elif future_invoices and payment.credit == future_amount:
+                    (future_lines + payment).reconcile()
+                    future_invoices = future_invoices.filtered(lambda i: i.payment_state != "paid")
 
-            # If no matching payment found, we will group or split.
-            if not is_past_reconciled:
-                past_invoices.with_delay()._group_or_split_reconcile()
-            if not is_future_reconciled:
-                future_invoices.with_delay()._group_or_split_reconcile()
-
+            # If no matching payment found, we will use leftovers with bigger credit.
+            if past_invoices:
+                past_lines.group_reconcile(mvl_obj.search(criterias))
+                future_invoices = future_invoices.filtered(lambda i: i.payment_state != "paid")
+            if future_invoices:
+                future_lines.group_reconcile(mvl_obj.search(criterias))
         return True
-
-    def _group_or_split_reconcile(self):
-        """
-        Find payments to reconcile given invoices and perform reconciliation.
-        :return: True
-        """
-        partner = self.mapped('partner_id')
-        partner.ensure_one()
-        reconcile_amount = sum(self.mapped('amount_total'))
-        move_lines = self.mapped('line_ids').filtered('debit')
-        payment_search = [
-            ('partner_id', '=', partner.id),
-            ('account_id.code', '=', '1050'),
-            ('reconciled', '=', False),
-            ('credit', '>', 0)
-        ]
-
-        line_obj = self.env['account.move.line']
-        payment_greater_than_reconcile = line_obj.search(
-            payment_search + [('credit', '>', reconcile_amount)],
-            order='date asc', limit=1)
-        if payment_greater_than_reconcile:
-            # Split the payment move line to isolate reconcile amount
-            return (payment_greater_than_reconcile | move_lines) \
-                .split_payment_and_reconcile()
-        else:
-            # Group several payments to match the invoiced amount
-            # Limit to 12 move_lines to avoid too many computations
-            open_payments = line_obj.search(payment_search, limit=12)
-            if sum(open_payments.mapped("credit")) < reconcile_amount:
-                raise UserError(_("Cannot reconcile invoices, not enough credit."))
-
-            # Search for a combination giving the invoiced amount recursively
-            # https://stackoverflow.com/questions/4632322/finding-all-possible-
-            # combinations-of-numbers-to-reach-a-given-sum
-            def find_sum(numbers, target, partial=None):
-                if partial is None:
-                    partial = []
-                s = sum(p.credit for p in partial)
-
-                if s == target:
-                    return partial
-                if s >= target:
-                    return  # if we reach the number why bother to continue
-
-                for i in range(len(numbers)):
-                    ret = find_sum(numbers[i + 1:], target,
-                                   partial + [numbers[i]])
-                    if ret is not None:
-                        return ret
-
-            matching_lines = line_obj
-            sum_found = find_sum(open_payments, reconcile_amount)
-            if sum_found is not None:
-                for payment in sum_found:
-                    matching_lines += payment
-                return (matching_lines | move_lines).reconcile()
-            else:
-                # No combination found: we must split one payment
-                payment_amount = 0
-                for index, payment_line in enumerate(open_payments):
-                    missing_amount = reconcile_amount - payment_amount
-                    if payment_line.credit > missing_amount:
-                        # Split last added line amount to perfectly match
-                        # the total amount we are looking for
-                        return (open_payments[:index + 1] | move_lines) \
-                            .split_payment_and_reconcile()
-                    payment_amount += payment_line.credit
-                return (open_payments | move_lines).reconcile()
 
     def update_invoices(self, updt_val):
         """

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -457,7 +457,7 @@ class RecurringContract(models.Model):
         for inv in paid_invoices:
             inv.write({"invoice_line_ids": [(2, invl.id) for invl in inv_lines_paid.exists() if invl.move_id == inv]})
         paid_invoices.action_post()
-        paid_invoices.with_company(self.mapped("company_id").id).reconcile_after_clean()
+        paid_invoices.with_company(self[0].company_id.id).reconcile_after_clean()
 
         # Cancel all open invoices
         invoices_lines = self._filter_open_invoices_to_cancel()

--- a/recurring_contract/models/res_config_settings.py
+++ b/recurring_contract/models/res_config_settings.py
@@ -20,14 +20,16 @@ class MandateStaffNotifSettings(models.TransientModel):
     # offset to know if we should generate current month or not
     do_generate_curr_month = fields.Boolean(
         string="Generate current month ?",
-        help="Define if the invoices should generate the current month by default or the next month. Ticked means we generate the current month and next month by default",
+        help="Define if the invoices should generate the current month by default or the next month."
+             "Ticked means we generate the current month and next month by default",
         default=True,
     )
     # Day to know when we should stop generating invoices for a specific contract group on a contract creation
     inv_block_day = fields.Selection(
         selection="_day_selection",
         string="Invoices Blocked Day",
-        help="Day at which we will suspend the invoices generation until the first of next month",
+        help="If set, contracts created after this day will set their first invoice one month after. "
+             "Contracts terminated after this day will cancel paid invoices one month after.",
         default="15",
     )
 


### PR DESCRIPTION
- Redo paid invoices cancellation, the process was the old version from 12.0 which was no longer adapted. It simplifies the process by not splitting payments but just make use of the reconcile function which correctly allocates partial amounts in case the payment is greater than the invoice.
- Make use of the invoice blocking day to decide whether cancelling the current month invoice or not.