### PR TITLE
FIX for contract invoices update

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -411,7 +411,7 @@ class ContractGroup(models.Model):
                             pay_mode_id=vals.get("payment_mode_id")
                         )
                     )
-                invoices.update_invoices(data_invs)
+                invoices.update_open_invoices(data_invs)
         if "advance_billing_months" in vals:
             # In case the advance_billing_months is greater than before we should generate more invoices
             self.active_contract_ids.button_generate_invoices()

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -526,4 +526,4 @@ class RecurringContract(models.Model):
                         )
                     )
             if data_invs:
-                self.mapped("invoice_line_ids.move_id").update_invoices(data_invs)
+                self.mapped("invoice_line_ids.move_id").update_open_invoices(data_invs)

--- a/recurring_contract/models/res_config_settings.py
+++ b/recurring_contract/models/res_config_settings.py
@@ -29,7 +29,8 @@ class MandateStaffNotifSettings(models.TransientModel):
         selection="_day_selection",
         string="Invoices Blocked Day",
         help="If set, contracts created after this day will set their first invoice one month after. "
-             "Contracts terminated after this day will cancel paid invoices one month after.",
+             "Contracts terminated after this day will cancel paid invoices one month after. "
+             "Changes made to a contract after this day will apply only on the next month.",
         default="15",
     )
 

--- a/recurring_contract/tests/test_account_move.py
+++ b/recurring_contract/tests/test_account_move.py
@@ -53,7 +53,7 @@ class AccountInvoiceTestCase(AccountTestInvoicingCommon):
                 'invoice_line_ids': [(1, self.invoice.invoice_line_ids[0].id, {'price_unit': 20.0})]
             }
         }
-        self.invoice.update_invoices(updt_val)
+        self.invoice.update_open_invoices(updt_val)
         self.assertEqual(self.invoice.amount_total, 20.0)
 
     def test_update_invoices_cancel_invoice(self):
@@ -66,7 +66,7 @@ class AccountInvoiceTestCase(AccountTestInvoicingCommon):
                 'invoice_line_ids': [(1, self.invoice.invoice_line_ids[0].id, {'price_unit': 0.0})]
             }
         }
-        self.invoice.update_invoices(updt_val)
+        self.invoice.update_open_invoices(updt_val)
         self.assertEqual(self.invoice.state, 'cancel')
 
     def test_update_invoices_post_invoice(self):
@@ -79,7 +79,7 @@ class AccountInvoiceTestCase(AccountTestInvoicingCommon):
                 'invoice_line_ids': [(1, self.invoice.invoice_line_ids[0].id, {'price_unit': 100.0})]
             }
         }
-        self.invoice.update_invoices(updt_val)
+        self.invoice.update_open_invoices(updt_val)
         self.assertEqual(self.invoice.amount_total, 100.0)
         self.assertEqual(self.invoice.state, 'posted')
 


### PR DESCRIPTION
- Update current month invoices so that if we make a change in contract during the month, the invoice for the current month is updated as well.
- Make an exception if we cross the invoice blocking date. In that case, update only starting from the next month.
- Refactor method name