### PR TITLE
CP-395 Put invoice generation into small jobs

### DIFF
--- a/recurring_contract/__init__.py
+++ b/recurring_contract/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizards
+from . import tools

--- a/recurring_contract/tools/__init__.py
+++ b/recurring_contract/tools/__init__.py
@@ -1,0 +1,4 @@
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]


### PR DESCRIPTION
- Instead of launching one job with all contract groups, use jobs for 100 groups at a time.
- Change query for selecting contracts to include
- WIP: the jobs don't generate any invoices! But when using the button generate invoice, it works.