### PR TITLE
CP-395 Cron doesnt generate invoices

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -295,11 +295,10 @@ class ContractGroup(models.Model):
                         invoice_err_gen = True
                         if not test_mode:
                             self.env.cr.rollback()
-
-            # Refresh state to check whether invoices are missing in some contracts
-            self.mapped("active_contract_ids")._compute_missing_invoices()
-            _logger.info("Proccess successfully generated invoices")
-            return invoicer.with_context({'invoice_err_gen': invoice_err_gen})
+        # Refresh state to check whether invoices are missing in some contracts
+        self.mapped("active_contract_ids")._compute_missing_invoices()
+        _logger.info("Proccess successfully generated invoices")
+        return invoicer.with_context({'invoice_err_gen': invoice_err_gen})
 
     def get_relative_invoice_date(self, date_to_compute):
         """ Calculate the date depending on the last day of the month and the invoice_day set in the contract.

--- a/recurring_contract/wizards/recurring_invoicer_wizard.py
+++ b/recurring_contract/wizards/recurring_invoicer_wizard.py
@@ -24,7 +24,7 @@ class InvoicerWizard(models.TransientModel):
 
     def generate(self):
         self.env.cr.execute(f"""
-        SELECT DISTINCT rc.id 
+        SELECT DISTINCT gr.id 
         FROM recurring_contract rc
         JOIN recurring_contract_group gr ON rc.group_id = gr.id
         WHERE rc.state IN ('active', 'waiting')
@@ -38,11 +38,11 @@ class InvoicerWizard(models.TransientModel):
             AND date_maturity >= CURRENT_DATE + (INTERVAL '1 month' * gr.advance_billing_months)
         )
         """)
-        contract_ids = [r[0] for r in self.env.cr.fetchall()]
-        contracts = self.env["recurring.contract"].browse(contract_ids)
+        group_ids = [r[0] for r in self.env.cr.fetchall()]
+        groups = self.env["recurring.contract"].browse(group_ids)
 
         # Add a job for all groups and start the job when all jobs are created.
-        invoicer = contracts.generate_invoices()
+        invoicer = groups.generate_invoices()
         res_id = False
         if invoicer:
             res_id = invoicer.id


### PR DESCRIPTION
The return wasn't indented correctly.
I adapted the invoicer to directly call the generation of invoices on the group and not via the contract which was a lost of time and perf.