### PR TITLE
T0095 modify contract to handle float quantity

### DIFF
--- a/recurring_contract/models/recurring_contract_line.py
+++ b/recurring_contract/models/recurring_contract_line.py
@@ -34,7 +34,7 @@ class ContractLine(models.Model):
     product_id = fields.Many2one('product.product', 'Product',
                                  required=True, readonly=False)
     amount = fields.Float('Price', required=True)
-    quantity = fields.Integer(default=1, required=True)
+    quantity = fields.Float(default=1, required=True)
     subtotal = fields.Float(compute='_compute_subtotal', store=True,
                             digits=dp.get_precision('Account'))
 


### PR DESCRIPTION
It's needed for the current survival contract that doesn't pay the future amount of the contract, so we will make some float quantity for them.