### PR TITLE
T0479 Set contract reference with next_by_code()

### DIFF
--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -136,10 +136,8 @@ class RecurringContract(models.Model):
 
     @api.model
     def create(self, vals):
-        """ Add a sequence generated ref if none is given """
-        if vals.get('reference', '/') == '/':
-            vals['reference'] = self.env['ir.sequence'].next_by_code(
-                'recurring.contract.ref')
+        """ Add a sequence generated ref """
+        vals['reference'] = self.env['ir.sequence'].next_by_code('recurring.contract.ref')
 
         return super().create(vals)
 


### PR DESCRIPTION
Ticket reference: T0479

When creating a new CSP sponsorship from an email request, the references wasn't set correctly,
With other contract types, the reference is always set with the next_by_code() function.
We should continue to do it for all contracts type, by removing this condition we force the reference to always give a contract reference with the pattern CON + numbers