### PR TITLE
T1593 - Fix invoice generation for Sub Accept with annual billing

### DIFF
--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -259,6 +259,24 @@ class RecurringContract(models.Model):
 
     def _compute_period_paid(self):
         for contract in self:
+            today = date.today()
+            current_billing_year = today.year
+
+            advance_billing = contract.group_id.advance_billing_months
+            to_pay_period = min(today.month + advance_billing, 12)
+
+            if today.month == 12 and today.day >= 15:
+                current_billing_year += 1
+                to_pay_period -= 12
+
+            months_to_pay = len(list(contract.open_invoice_ids.filtered(
+                lambda invoice: invoice.date.month <= to_pay_period and invoice.date.year == current_billing_year)))
+
+            contract.period_paid = months_to_pay == 0
+
+            return
+
+
             advance_billing = contract.group_id.advance_billing_months
             this_month = date.today().month
             # Don't consider next year in the period to pay

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -272,8 +272,10 @@ class RecurringContract(models.Model):
             months_to_pay = len(
                 list(
                     contract.open_invoice_ids.filtered(
-                        lambda invoice: invoice.date.month <= to_pay_period
-                        and invoice.date.year == current_billing_year
+                        lambda invoice,
+                        period=to_pay_period,
+                        year=current_billing_year: invoice.date.month <= period
+                        and invoice.date.year == year
                     )
                 )
             )

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -269,22 +269,16 @@ class RecurringContract(models.Model):
                 current_billing_year += 1
                 to_pay_period -= 12
 
-            months_to_pay = len(list(contract.open_invoice_ids.filtered(
-                lambda invoice: invoice.date.month <= to_pay_period and invoice.date.year == current_billing_year)))
+            months_to_pay = len(
+                list(
+                    contract.open_invoice_ids.filtered(
+                        lambda invoice: invoice.date.month <= to_pay_period
+                        and invoice.date.year == current_billing_year
+                    )
+                )
+            )
 
             contract.period_paid = months_to_pay == 0
-
-            return
-
-
-            advance_billing = contract.group_id.advance_billing_months
-            this_month = date.today().month
-            # Don't consider next year in the period to pay
-            to_pay_period = min(this_month + advance_billing, 12)
-            # Exception for december, we will consider next year
-            if this_month == 12:
-                to_pay_period += advance_billing
-            contract.period_paid = contract.months_paid >= to_pay_period
 
     def _compute_months_paid(self):
         """This is a query returning the number of months paid for the current year."""


### PR DESCRIPTION
# Description
There was a crash related to how we handle the generation of the Sub Accept correspondance. It is a very specific case where a sponsor that pays annually had his sponsorship finish earlier and then accepted a new child sponsorship.

The issue comes from the fact that since he had already payed the current year's invoices for the previous child, he has no more invoices for the current year, only some for the next year. But when checking if the current period is payed using `_compute_period_paid`, it returned `False` since it does not take into account the current billing year, it simply checks all unpaid invoices.

Later down the line this causes a crash when generating the Sub Accept correspondence since we get into an [error state](https://github.com/CompassionCH/compassion-switzerland/blob/0594a43175d8b2a67436f766bd9d16b5e6b017ae/report_compassion/models/contract_group.py#L53-L54) because the first unpaid invoice comes after the last month of the current year.

# Technical Aspects
The code itself is pretty simple, we just changed `_compute_period_paid` to only check the unpaid invoices of the current billing year.
