### PR TITLE
T1657 - Fix invoice generation for Sub Proposal (1/3)

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -482,7 +482,7 @@ class ContractGroup(models.Model):
                     (
                         "product_id",
                         "in",
-                        contracts.product_ids.ids,
+                        contracts.mapped("product_ids").ids,
                     ),
                     ("payment_state", "=", "paid"),
                 ]
@@ -491,7 +491,7 @@ class ContractGroup(models.Model):
         )
         reference_contract = contracts[0]
         company_id = reference_contract.company_id.id
-        partner_id = self._get_partner_for_contract(contract).id
+        partner_id = self._get_partner_for_contract(reference_contract).id
         journal = self.env["account.journal"].search(
             [("type", "=", "sale"), ("company_id", "=", company_id)], limit=1
         )

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -316,10 +316,9 @@ class ContractGroup(models.Model):
         - There is already an invoice for this due date which has been cancelled or
           edited.
         - Contract group suspension.
+        - A specific contract is given and an invoice for this due date have already exists and isn't cancelled
         """
         self.ensure_one()
-
-        search_filter = []
 
         if contract:
             # I changed the logic here... If the given contract already has an invoice for that month that is not cancelled -> skip it
@@ -373,10 +372,9 @@ class ContractGroup(models.Model):
 
     def _process_invoice_generation(self, invoicer, invoicing_date, contract=None):
         self.ensure_one()
-        # active_contracts = contract if contract else self.active_contract_ids
         active_contracts = self.active_contract_ids
         open_invoices = self.active_contract_ids.mapped("open_invoice_ids").filtered(
-            lambda i: i.invoice_date_due >= invoicing_date and i.invoice_date_due.year == invoicing_date.year # ADDED CHECK FOR SAME INVOICING YEAR
+            lambda i: i.invoice_date_due >= invoicing_date and i.invoice_date_due.year == invoicing_date.year
         )
 
         # invoice already open we complete the move lines
@@ -386,9 +384,9 @@ class ContractGroup(models.Model):
         open_invoice = open_invoices.filtered(
             lambda m: getattr(m.invoice_date_due, self.recurring_unit) == current_rec_unit_date
         )
-        if len(open_invoice) > 1: # NOT SURE ABOUT THIS, IT DOESN'T SEEM TO MAKE SENSE TO HAVE MORE THAN ONE
-            _logger.warning(
-                f"Found more than one open invoice on {invoicing_date} for {self.id}"
+        if len(open_invoice) > 1:
+            _logger.error(
+                f"Found more than one open invoice on {invoicing_date} for the group {self.id}"
             )
             return False
 
@@ -443,7 +441,12 @@ class ContractGroup(models.Model):
             )
         else:
             # Building invoices data
-            inv_data = self._build_invoice_gen_data(invoicing_date, invoicer, contract if contract is not None else self.active_contract_ids[0])
+            if contract is None:
+                # we use the first contract because the information we retrieve has to be shared
+                # between all the contracts of the list
+                contract = self.active_contract_ids[0]
+
+            inv_data = self._build_invoice_gen_data(invoicing_date, invoicer, contract)
             # Creating the actual invoice
             _logger.info(f"Generating invoice : {inv_data}")
             invoice = self.env["account.move"].create(inv_data)
@@ -480,8 +483,6 @@ class ContractGroup(models.Model):
             )
             .mapped("contract_id.contract_line_ids")
         )
-        # we use the first contract because the information we retrieve has to be shared
-        # between all the contracts of the list
         company_id = contract.company_id.id
         partner_id = self._get_partner_for_contract(contract).id
         journal = self.env["account.journal"].search(
@@ -521,7 +522,10 @@ class ContractGroup(models.Model):
                         invoicing_date=invoicing_date, contract_line=cl
                     ),
                 )
-                for cl in ( # not sure about this one bro... this is why the invoices are doubled/trippled/quadruppled ect...
+                # This loop is the cause in invoices being doubled/tripled/...
+                # We should only get here if there is not an existing open invoice for this period,
+                # so before there was no reason to reference the contract_line_ids of the other active invoices
+                for cl in (
                     contract.contract_line_ids - already_paid_cl
                 )
                 if cl

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -269,7 +269,9 @@ class ContractGroup(models.Model):
                 )
 
                 # Check if invoice generation should be skipped for this date
-                if group._should_skip_invoice_generation(current_invoicing_date, contract):
+                if group._should_skip_invoice_generation(
+                    current_invoicing_date, contract
+                ):
                     continue
 
                 # Create a unique key for the invoice to track it
@@ -278,7 +280,9 @@ class ContractGroup(models.Model):
                 # Check if the invoice for this key has already been processed
                 if invoice_key not in processed_invoices:
                     # Process invoice generation if not already processed
-                    group._process_invoice_generation(invoicer, current_invoicing_date, contract)
+                    group._process_invoice_generation(
+                        invoicer, current_invoicing_date, contract
+                    )
                     # Add the invoice key to the set of processed invoices
                     processed_invoices.add(invoice_key)
 
@@ -336,7 +340,7 @@ class ContractGroup(models.Model):
                     "line_ids.product_id",
                     "in",
                     contract.product_ids.ids,
-                )
+                ),
             ]
         else:
             search_filter = [
@@ -356,7 +360,8 @@ class ContractGroup(models.Model):
                     "line_ids.product_id",
                     "in",
                     self.active_contract_ids.mapped("product_ids").ids,
-                )]
+                ),
+            ]
 
         existing_invoices = self.env["account.move"].search(search_filter)
 
@@ -376,7 +381,8 @@ class ContractGroup(models.Model):
         self.ensure_one()
         active_contracts = self.active_contract_ids
         open_invoices = self.active_contract_ids.mapped("open_invoice_ids").filtered(
-            lambda i: i.invoice_date_due >= invoicing_date and i.invoice_date_due.year == invoicing_date.year
+            lambda i: i.invoice_date_due >= invoicing_date
+            and i.invoice_date_due.year == invoicing_date.year
         )
 
         # invoice already open we complete the move lines
@@ -384,7 +390,8 @@ class ContractGroup(models.Model):
         # Keep invoice from the same month or year
         # (depending on the recurring unit)
         open_invoice = open_invoices.filtered(
-            lambda m: getattr(m.invoice_date_due, self.recurring_unit) == current_rec_unit_date
+            lambda m: getattr(m.invoice_date_due, self.recurring_unit)
+            == current_rec_unit_date
         )
         if len(open_invoice) > 1:
             _logger.error(
@@ -462,7 +469,9 @@ class ContractGroup(models.Model):
                 )
                 invoice.unlink()
 
-    def _build_invoice_gen_data(self, invoicing_date, invoicer, contract, gift_wizard=False):
+    def _build_invoice_gen_data(
+        self, invoicing_date, invoicer, contract, gift_wizard=False
+    ):
         """Setup a dict with data passed to invoice.create.
         If any custom data is wanted in invoice from contract group, just
         inherit this method.
@@ -524,9 +533,7 @@ class ContractGroup(models.Model):
                         invoicing_date=invoicing_date, contract_line=cl
                     ),
                 )
-                for cl in (
-                    contract.contract_line_ids - already_paid_cl
-                )
+                for cl in (contract.contract_line_ids - already_paid_cl)
                 if cl
             ],
             "narration": "\n".join(

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -519,9 +519,7 @@ class ContractGroup(models.Model):
                         invoicing_date=invoicing_date, contract_line=cl
                     ),
                 )
-                for cl in (
-                    contracts.mapped("contract_line_ids") - already_paid_cl
-                )
+                for cl in (contracts.mapped("contract_line_ids") - already_paid_cl)
                 if cl
             ],
             "narration": "\n".join(

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -382,7 +382,7 @@ class ContractGroup(models.Model):
     def _process_invoice_generation(self, invoicer, invoicing_date, contract=None):
         self.ensure_one()
         active_contracts = self.active_contract_ids
-        open_invoices = self.active_contract_ids.mapped("open_invoice_ids").filtered(
+        open_invoices = active_contracts.mapped("open_invoice_ids").filtered(
             lambda i: i.invoice_date_due >= invoicing_date
             and i.invoice_date_due.year == invoicing_date.year
         )

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -366,7 +366,7 @@ class ContractGroup(models.Model):
 
         existing_invoices = self.env["account.move"].search(search_filter)
 
-        is_sub_proposal = contract is not None and contract.source_id is 554
+        is_sub_proposal = contract is not None and contract.source_id == 554
 
         # Check for contract group suspension when no specific contract is given
         # from a sub proposal is given

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -356,18 +356,12 @@ class ContractGroup(models.Model):
 
         existing_invoices = self.env["account.move"].search_count(search_filter)
 
-        is_sub_proposal = contract is not None and contract.source_id.id == 554
+        is_suspended = (
+            self.invoice_suspended_until
+            and self.invoice_suspended_until > invoicing_date
+        )
 
-        # Check for contract group suspension when no specific contract is given
-        # from a sub proposal is given
-        if is_sub_proposal:
-            return bool(existing_invoices)
-        else:
-            is_suspended = (
-                self.invoice_suspended_until
-                and self.invoice_suspended_until > invoicing_date
-            )
-            return bool(existing_invoices) or is_suspended
+        return bool(existing_invoices) or is_suspended
 
     def _process_invoice_generation(self, invoicer, invoicing_date, contract=None):
         self.ensure_one()

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -194,12 +194,12 @@ class ContractGroup(models.Model):
             "context": {"search_default_unpaid": 1},
         }
 
-    def button_generate_invoices(self):
+    def button_generate_invoices(self, contract_id=None):
         """Immediately generate invoices for the contract group."""
         invoicer = (
             self.with_context({"async_mode": False})
             .with_company(self.active_contract_ids[0].company_id)
-            .generate_invoices()
+            .generate_invoices(contract_id)
         )
         if invoicer.invoice_ids:
             notification_type = "success"
@@ -224,7 +224,7 @@ class ContractGroup(models.Model):
     ##########################################################################
     #                             PRIVATE METHODS                            #
     ##########################################################################
-    def generate_invoices(self):
+    def generate_invoices(self, contract_id=None):
         """By default, launch asynchronous job to perform the task.
         Context value async_mode set to False can force to perform
         the task immediately.
@@ -232,12 +232,12 @@ class ContractGroup(models.Model):
         invoicer = self.env["recurring.invoicer"].create({})
         if self.env.context.get("async_mode", True):
             for group in self:
-                group.with_delay()._generate_invoices(invoicer)
+                group.with_delay()._generate_invoices(invoicer, contract_id)
         else:
-            self._generate_invoices(invoicer)
+            self._generate_invoices(invoicer, contract_id)
         return invoicer
 
-    def _generate_invoices(self, invoicer):
+    def _generate_invoices(self, invoicer, contract_id=None):
         """Checks all contracts and generate invoices if needed.
         Create an invoice per contract group per date.
         """
@@ -247,6 +247,13 @@ class ContractGroup(models.Model):
 
         # Set to track processed invoices to avoid duplication
         processed_invoices = set()
+
+        contract = None
+        if contract_id:
+            contract = self.env["recurring.contract"].browse(contract_id)
+            if not contract:
+                _logger.error(f"The contract with the id {contract_id} does not exist.")
+                return False
 
         for group in self:
             # Calculate the initial invoicing date and starting offset
@@ -262,7 +269,7 @@ class ContractGroup(models.Model):
                 )
 
                 # Check if invoice generation should be skipped for this date
-                if group._should_skip_invoice_generation(current_invoicing_date):
+                if group._should_skip_invoice_generation(current_invoicing_date, contract):
                     continue
 
                 # Create a unique key for the invoice to track it
@@ -271,7 +278,7 @@ class ContractGroup(models.Model):
                 # Check if the invoice for this key has already been processed
                 if invoice_key not in processed_invoices:
                     # Process invoice generation if not already processed
-                    group._process_invoice_generation(invoicer, current_invoicing_date)
+                    group._process_invoice_generation(invoicer, current_invoicing_date, contract)
                     # Add the invoice key to the set of processed invoices
                     processed_invoices.add(invoice_key)
 
@@ -304,47 +311,72 @@ class ContractGroup(models.Model):
             offset = 1
         return start_date, offset
 
-    def _should_skip_invoice_generation(self, invoicing_date):
+    def _should_skip_invoice_generation(self, invoicing_date, contract=None):
         """In such cases, we should skip the invoice generation:
         - There is already an invoice for this due date which has been cancelled or
           edited.
         - Contract group suspension.
         """
         self.ensure_one()
-        dangling_invoices = self.env["account.move"].search(
-            [
-                "|",
+
+        search_filter = []
+
+        if contract:
+            # I changed the logic here... If the given contract already has an invoice for that month that is not cancelled -> skip it
+            search_filter = [
                 "&",
+                "&",
+                "&",
+                "&",
+                "&",
+                ("state", "!=", "cancel"),
                 ("invoice_date_due", "=", invoicing_date),
                 ("partner_id", "=", self.partner_id.id),
-                "&",
-                "&",
-                "&",
-                "&",
                 ("move_type", "=", "out_invoice"),
-                ("state", "=", "cancel"),
+                ("line_ids.contract_id", "=", contract.id),
+                (
+                    "line_ids.product_id",
+                    "in",
+                    contract.product_ids.ids,
+                )
+            ]
+        else:
+            search_filter = [
+                "&",
+                "&",
+                "&",
+                "&",
+                "&",
+                "|",
                 ("payment_state", "not in", ["paid", "not_paid"]),
+                ("state", "=", "cancel"),
+                ("invoice_date_due", "=", invoicing_date),
+                ("partner_id", "=", self.partner_id.id),
+                ("move_type", "=", "out_invoice"),
                 ("line_ids.contract_id", "in", self.active_contract_ids.ids),
                 (
                     "line_ids.product_id",
                     "in",
                     self.active_contract_ids.mapped("product_ids").ids,
-                ),
-            ]
-        )
+                )]
+
+        dangling_invoices = self.env["account.move"].search(search_filter)
+
         # Check for contract group suspension
-        is_suspended = (
+        # Should this really be checked ???? I feel like it's always today + 1 month so no prior invoices will ever be created...
+        is_suspended = False if contract is not None and contract.source_id is not 554 else (
             self.invoice_suspended_until
             and self.invoice_suspended_until > invoicing_date
         )
 
         return bool(dangling_invoices) or is_suspended
 
-    def _process_invoice_generation(self, invoicer, invoicing_date):
+    def _process_invoice_generation(self, invoicer, invoicing_date, contract=None):
         self.ensure_one()
+        # active_contracts = contract if contract else self.active_contract_ids
         active_contracts = self.active_contract_ids
-        open_invoices = active_contracts.mapped("open_invoice_ids").filtered(
-            lambda i: i.invoice_date_due >= invoicing_date
+        open_invoices = self.active_contract_ids.mapped("open_invoice_ids").filtered(
+            lambda i: i.invoice_date_due >= invoicing_date and i.invoice_date_due.year == invoicing_date.year # ADDED CHECK FOR SAME INVOICING YEAR
         )
 
         # invoice already open we complete the move lines
@@ -352,10 +384,9 @@ class ContractGroup(models.Model):
         # Keep invoice from the same month or year
         # (depending on the recurring unit)
         open_invoice = open_invoices.filtered(
-            lambda m: getattr(m.invoice_date_due, self.recurring_unit)
-            == current_rec_unit_date
+            lambda m: getattr(m.invoice_date_due, self.recurring_unit) == current_rec_unit_date
         )
-        if open_invoice:
+        if open_invoice: # THIS ONE SEEMS CORRECTIMUNDO
             # Retrieve account_move_line already existing for this contract
             acc_move_line_curr_contr = open_invoice.mapped("invoice_line_ids").filtered(
                 lambda line: line.contract_id in active_contracts
@@ -406,7 +437,7 @@ class ContractGroup(models.Model):
             )
         else:
             # Building invoices data
-            inv_data = self._build_invoice_gen_data(invoicing_date, invoicer)
+            inv_data = self._build_invoice_gen_data(invoicing_date, invoicer, contract if contract is not None else self.active_contract_ids[0])
             # Creating the actual invoice
             _logger.info(f"Generating invoice : {inv_data}")
             invoice = self.env["account.move"].create(inv_data)
@@ -420,11 +451,12 @@ class ContractGroup(models.Model):
                 )
                 invoice.unlink()
 
-    def _build_invoice_gen_data(self, invoicing_date, invoicer, gift_wizard=False):
+    def _build_invoice_gen_data(self, invoicing_date, invoicer, contract, gift_wizard=False):
         """Setup a dict with data passed to invoice.create.
         If any custom data is wanted in invoice from contract group, just
         inherit this method.
         """
+        # THISSSSSSSSSSSSSSSSSSSSSSSSSSS
         self.ensure_one()
         # Filter the contract line already paid
         already_paid_cl = (
@@ -445,7 +477,6 @@ class ContractGroup(models.Model):
         )
         # we use the first contract because the information we retrieve has to be shared
         # between all the contracts of the list
-        contract = self.active_contract_ids[0]
         company_id = contract.company_id.id
         partner_id = self._get_partner_for_contract(contract).id
         journal = self.env["account.journal"].search(
@@ -485,9 +516,8 @@ class ContractGroup(models.Model):
                         invoicing_date=invoicing_date, contract_line=cl
                     ),
                 )
-                for cl in (
-                    self.mapped("active_contract_ids.contract_line_ids")
-                    - already_paid_cl
+                for cl in ( # not sure about this one bro... this is why the invoices are doubled/trippled/quadruppled ect...
+                    contract.contract_line_ids - already_paid_cl
                 )
                 if cl
             ],

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -386,7 +386,13 @@ class ContractGroup(models.Model):
         open_invoice = open_invoices.filtered(
             lambda m: getattr(m.invoice_date_due, self.recurring_unit) == current_rec_unit_date
         )
-        if open_invoice: # THIS ONE SEEMS CORRECTIMUNDO
+        if len(open_invoice) > 1: # NOT SURE ABOUT THIS, IT DOESN'T SEEM TO MAKE SENSE TO HAVE MORE THAN ONE
+            _logger.warning(
+                f"Found more than one open invoice on {invoicing_date} for {self.id}"
+            )
+            return False
+
+        if open_invoice:
             # Retrieve account_move_line already existing for this contract
             acc_move_line_curr_contr = open_invoice.mapped("invoice_line_ids").filtered(
                 lambda line: line.contract_id in active_contracts
@@ -456,7 +462,6 @@ class ContractGroup(models.Model):
         If any custom data is wanted in invoice from contract group, just
         inherit this method.
         """
-        # THISSSSSSSSSSSSSSSSSSSSSSSSSSS
         self.ensure_one()
         # Filter the contract line already paid
         already_paid_cl = (

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -380,11 +380,7 @@ class ContractGroup(models.Model):
             == current_rec_unit_date
         )
         if len(open_invoice) > 1:
-            _logger.error(
-                f"Found more than one open invoice on {invoicing_date}"
-                f"for the group {self.id}"
-            )
-            return False
+            raise ValueError(f"Found more than one open invoice on {invoicing_date}.")
 
         if open_invoice:
             # Retrieve account_move_line already existing for this contract

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -446,8 +446,6 @@ class ContractGroup(models.Model):
             contracts = self.active_contract_ids
 
             if contract is not None:
-                # we use the first contract because the information we retrieve
-                # has to be shared between all the contracts of the list
                 contracts = contract
 
             inv_data = self._build_invoice_gen_data(invoicing_date, invoicer, contracts)
@@ -489,6 +487,8 @@ class ContractGroup(models.Model):
             )
             .mapped("contract_id.contract_line_ids")
         )
+        # we use the first contract because the information we retrieve
+        # has to be shared between all the contracts of the list
         reference_contract = contracts[0]
         company_id = reference_contract.company_id.id
         partner_id = self._get_partner_for_contract(reference_contract).id

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -320,7 +320,8 @@ class ContractGroup(models.Model):
         - There is already an invoice for this due date which has been cancelled or
           edited.
         - Contract group suspension.
-        - A specific contract is given and an invoice for this due date have already exists and isn't cancelled
+        - A specific contract is given and an invoice for this due date already exists
+          and isn't cancelled.
         """
         self.ensure_one()
 
@@ -367,7 +368,8 @@ class ContractGroup(models.Model):
 
         is_sub_proposal = contract is not None and contract.source_id is 554
 
-        # Check for contract group suspension when no specific contract is given from a sub proposal is given
+        # Check for contract group suspension when no specific contract is given
+        # from a sub proposal is given
         if is_sub_proposal:
             return bool(existing_invoices)
         else:
@@ -395,7 +397,8 @@ class ContractGroup(models.Model):
         )
         if len(open_invoice) > 1:
             _logger.error(
-                f"Found more than one open invoice on {invoicing_date} for the group {self.id}"
+                f"Found more than one open invoice on {invoicing_date}"
+                f"for the group {self.id}"
             )
             return False
 
@@ -451,8 +454,8 @@ class ContractGroup(models.Model):
         else:
             # Building invoices data
             if contract is None:
-                # we use the first contract because the information we retrieve has to be shared
-                # between all the contracts of the list
+                # we use the first contract because the information we retrieve
+                # has to be shared between all the contracts of the list
                 contract = self.active_contract_ids[0]
 
             inv_data = self._build_invoice_gen_data(invoicing_date, invoicer, contract)

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -327,11 +327,6 @@ class ContractGroup(models.Model):
 
         if contract:
             search_filter = [
-                "&",
-                "&",
-                "&",
-                "&",
-                "&",
                 ("state", "!=", "cancel"),
                 ("invoice_date_due", "=", invoicing_date),
                 ("partner_id", "=", self.partner_id.id),
@@ -345,14 +340,6 @@ class ContractGroup(models.Model):
             ]
         else:
             search_filter = [
-                "&",
-                "&",
-                "&",
-                "&",
-                "&",
-                "|",
-                ("payment_state", "not in", ["paid", "not_paid"]),
-                ("state", "=", "cancel"),
                 ("invoice_date_due", "=", invoicing_date),
                 ("partner_id", "=", self.partner_id.id),
                 ("move_type", "=", "out_invoice"),
@@ -362,9 +349,12 @@ class ContractGroup(models.Model):
                     "in",
                     self.active_contract_ids.mapped("product_ids").ids,
                 ),
+                "|",
+                ("payment_state", "not in", ["paid", "not_paid"]),
+                ("state", "=", "cancel"),
             ]
 
-        existing_invoices = self.env["account.move"].search(search_filter)
+        existing_invoices = self.env["account.move"].search_count(search_filter)
 
         is_sub_proposal = contract is not None and contract.source_id == 554
 

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -356,7 +356,7 @@ class ContractGroup(models.Model):
 
         existing_invoices = self.env["account.move"].search_count(search_filter)
 
-        is_sub_proposal = contract is not None and contract.source_id == 554
+        is_sub_proposal = contract is not None and contract.source_id.id == 554
 
         # Check for contract group suspension when no specific contract is given
         # from a sub proposal is given
@@ -443,12 +443,14 @@ class ContractGroup(models.Model):
             )
         else:
             # Building invoices data
-            if contract is None:
+            contracts = self.active_contract_ids
+
+            if contract is not None:
                 # we use the first contract because the information we retrieve
                 # has to be shared between all the contracts of the list
-                contract = self.active_contract_ids[0]
+                contracts = contract
 
-            inv_data = self._build_invoice_gen_data(invoicing_date, invoicer, contract)
+            inv_data = self._build_invoice_gen_data(invoicing_date, invoicer, contracts)
             # Creating the actual invoice
             _logger.info(f"Generating invoice : {inv_data}")
             invoice = self.env["account.move"].create(inv_data)
@@ -463,7 +465,7 @@ class ContractGroup(models.Model):
                 invoice.unlink()
 
     def _build_invoice_gen_data(
-        self, invoicing_date, invoicer, contract, gift_wizard=False
+        self, invoicing_date, invoicer, contracts, gift_wizard=False
     ):
         """Setup a dict with data passed to invoice.create.
         If any custom data is wanted in invoice from contract group, just
@@ -476,18 +478,19 @@ class ContractGroup(models.Model):
             .search(
                 [
                     ("date", "=", invoicing_date),
-                    ("contract_id", "in", self.active_contract_ids.ids),
+                    ("contract_id", "in", contracts.ids),
                     (
                         "product_id",
                         "in",
-                        self.active_contract_ids.mapped("product_ids").ids,
+                        contracts.product_ids.ids,
                     ),
                     ("payment_state", "=", "paid"),
                 ]
             )
             .mapped("contract_id.contract_line_ids")
         )
-        company_id = contract.company_id.id
+        reference_contract = contracts[0]
+        company_id = reference_contract.company_id.id
         partner_id = self._get_partner_for_contract(contract).id
         journal = self.env["account.journal"].search(
             [("type", "=", "sale"), ("company_id", "=", company_id)], limit=1
@@ -498,10 +501,10 @@ class ContractGroup(models.Model):
             "move_type": "out_invoice",
             "partner_id": partner_id,
             "journal_id": journal.id,
-            "currency_id": contract.pricelist_id.currency_id.id,
+            "currency_id": reference_contract.pricelist_id.currency_id.id,
             "invoice_date": invoicing_date,  # Accountant date
             "recurring_invoicer_id": invoicer.id,
-            "pricelist_id": contract.pricelist_id.id,
+            "pricelist_id": reference_contract.pricelist_id.id,
             "payment_mode_id": self.payment_mode_id.id,
             "company_id": company_id,
             # Field for the invoice_due_date to be automatically calculated
@@ -526,7 +529,9 @@ class ContractGroup(models.Model):
                         invoicing_date=invoicing_date, contract_line=cl
                     ),
                 )
-                for cl in (contract.contract_line_ids - already_paid_cl)
+                for cl in (
+                    contracts.mapped("contract_line_ids") - already_paid_cl
+                )
                 if cl
             ],
             "narration": "\n".join(

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -321,7 +321,6 @@ class ContractGroup(models.Model):
         self.ensure_one()
 
         if contract:
-            # I changed the logic here... If the given contract already has an invoice for that month that is not cancelled -> skip it
             search_filter = [
                 "&",
                 "&",
@@ -359,16 +358,19 @@ class ContractGroup(models.Model):
                     self.active_contract_ids.mapped("product_ids").ids,
                 )]
 
-        dangling_invoices = self.env["account.move"].search(search_filter)
+        existing_invoices = self.env["account.move"].search(search_filter)
 
-        # Check for contract group suspension
-        # Should this really be checked ???? I feel like it's always today + 1 month so no prior invoices will ever be created...
-        is_suspended = False if contract is not None and contract.source_id is not 554 else (
-            self.invoice_suspended_until
-            and self.invoice_suspended_until > invoicing_date
-        )
+        is_sub_proposal = contract is not None and contract.source_id is 554
 
-        return bool(dangling_invoices) or is_suspended
+        # Check for contract group suspension when no specific contract is given from a sub proposal is given
+        if is_sub_proposal:
+            return bool(existing_invoices)
+        else:
+            is_suspended = (
+                self.invoice_suspended_until
+                and self.invoice_suspended_until > invoicing_date
+            )
+            return bool(existing_invoices) or is_suspended
 
     def _process_invoice_generation(self, invoicer, invoicing_date, contract=None):
         self.ensure_one()

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -524,9 +524,6 @@ class ContractGroup(models.Model):
                         invoicing_date=invoicing_date, contract_line=cl
                     ),
                 )
-                # This loop is the cause in invoices being doubled/tripled/...
-                # We should only get here if there is not an existing open invoice for this period,
-                # so before there was no reason to reference the contract_line_ids of the other active invoices
                 for cl in (
                     contract.contract_line_ids - already_paid_cl
                 )

--- a/recurring_contract/models/move.py
+++ b/recurring_contract/models/move.py
@@ -171,7 +171,9 @@ class AccountMove(models.Model):
         ):
             if updt_val.get(invoice.name):
                 val_to_updt = updt_val[invoice.name]
-                if 'partner_id' in val_to_updt and val_to_updt['partner_id'] == invoice.partner_id.id:
+                if ('partner_id' in val_to_updt
+                    and val_to_updt['partner_id'] == invoice.partner_id.id
+                ):
                     del val_to_updt['partner_id']
                     if not val_to_updt:
                         continue

--- a/recurring_contract/models/move.py
+++ b/recurring_contract/models/move.py
@@ -171,10 +171,11 @@ class AccountMove(models.Model):
         ):
             if updt_val.get(invoice.name):
                 val_to_updt = updt_val[invoice.name]
-                if ('partner_id' in val_to_updt
-                    and val_to_updt['partner_id'] == invoice.partner_id.id
+                if (
+                    "partner_id" in val_to_updt
+                    and val_to_updt["partner_id"] == invoice.partner_id.id
                 ):
-                    del val_to_updt['partner_id']
+                    del val_to_updt["partner_id"]
                     if not val_to_updt:
                         continue
                 # In case we modify the amount we want to test if the amount is zero

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -371,14 +371,14 @@ class RecurringContract(models.Model):
     #                             PUBLIC METHODS                             #
     ##########################################################################
     def button_generate_invoices(self):
-        return self.mapped("group_id").button_generate_invoices()
+        return self.mapped("group_id").button_generate_invoices(self.id)
 
     def generate_invoices(self):
         """By default, launch asynchronous job to perform the task.
         Context value async_mode set to False can force to perform
         the task immediately.
         """
-        self.mapped("group_id").generate_invoices()
+        self.mapped("group_id").generate_invoices(self.id)
 
     def cancel_contract_invoices(self):
         """By default, launch asynchronous job to perform the task.


### PR DESCRIPTION
# Description
There is a bug that occurs when generating the invoices for a new Sub Proposal, some invoices are not generated at all.
When looking into it it seems that the check of if we need to generate the invoice was wrong because it did not take into account for which contract we are generating the invoice for. Meaning that if any other active contract already had an invoice for that month, we would skip it.

# Technical Aspects
There area lot of small changes here and there, to make things simple two aspects were changed :
- When generating invoices, if a specific contract is given we use it as a reference to check and generate invoices
- Fixed some conditions for when new invoice lines should be generated or "appended" to existing open invoices

# Misc
- Changes in `move.py` is just related to pre-commit formatting