### PR TITLE
T1721 - Generate gift wizard uses the wrong partner

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -447,11 +447,7 @@ class ContractGroup(models.Model):
         # between all the contracts of the list
         contract = self.active_contract_ids[0]
         company_id = contract.company_id.id
-        partner_id = (
-            self.partner_id.id
-            if not contract.send_gifts_to
-            else contract[contract.send_gifts_to].id
-        )
+        partner_id = self._get_partner_for_contract(contract).id
         journal = self.env["account.journal"].search(
             [("type", "=", "sale"), ("company_id", "=", company_id)], limit=1
         )
@@ -567,3 +563,6 @@ class ContractGroup(models.Model):
             # In case the advance_billing_months is greater than before
             # we should generate more invoices
             self.active_contract_ids.button_generate_invoices()
+
+    def _get_partner_for_contract(self, contract):
+        return contract.partner_id

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -447,7 +447,11 @@ class ContractGroup(models.Model):
         # between all the contracts of the list
         contract = self.active_contract_ids[0]
         company_id = contract.company_id.id
-        partner_id = self.partner_id.id
+        partner_id = (
+            self.partner_id.id
+            if not contract.send_gifts_to
+            else contract[contract.send_gifts_to].id
+        )
         journal = self.env["account.journal"].search(
             [("type", "=", "sale"), ("company_id", "=", company_id)], limit=1
         )


### PR DESCRIPTION
Create the invoice for the `send_gifts_to` target, defaults to `partner_id` if not set.

**Note**: The first contract is used to get `send_gifts_to`, as the current code does for other fields.

CompassionCH/compassion-modules#1949