### PR TITLE
T1657 - Fix dupplicate invoice generation with CRON

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -317,11 +317,12 @@ class ContractGroup(models.Model):
 
     def _should_skip_invoice_generation(self, invoicing_date, contract=None):
         """In such cases, we should skip the invoice generation:
-        - There is already an invoice for this due date which has been cancelled or
-          edited.
-        - Contract group suspension.
         - A specific contract is given and an invoice for this due date already exists
           and isn't cancelled.
+        - All active contracts already have an invoice for this due date that
+          isn't cancelled.
+        - Contract group suspension.
+
         """
         self.ensure_one()
 
@@ -347,20 +348,14 @@ class ContractGroup(models.Model):
                 ("invoice_date_due", "=", invoicing_date),
                 ("partner_id", "=", self.partner_id.id),
                 ("move_type", "=", "out_invoice"),
-                ("line_ids.contract_id", "in", self.active_contract_ids.ids), # ----> should check that it found count == active_contracts.count ? if not if a single other active contract has an invoice it will not generate or update the amount
+                ("line_ids.contract_id", "in", self.active_contract_ids.ids),
                 (
                     "line_ids.product_id",
                     "in",
                     self.active_contract_ids.mapped("product_ids").ids,
                 ),
                 ('state', '!=', 'cancel')
-                #"|",
-                #("payment_state", "not in", ["paid", "not_paid"]),
-                #("state", "=", "cancel"), # ----> change double condition to ("state", "!=", "cancel") ?????
             ]
-
-            # self.env["account.move"].search([("invoice_date_due", "=", invoicing_date), ("partner_id", "=", self.partner_id.id), ("move_type", "=", "out_invoice"), ("line_ids.contract_id", "in", self.active_contract_ids.ids), ("state", "!=", "cancel")])
-            # 31551
 
             open_invoices = self.env["account.move"].search(search_filter)
 

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -325,6 +325,8 @@ class ContractGroup(models.Model):
         """
         self.ensure_one()
 
+        has_all_invoices = False
+
         if contract:
             search_filter = [
                 ("state", "!=", "cancel"),
@@ -338,6 +340,8 @@ class ContractGroup(models.Model):
                     contract.product_ids.ids,
                 ),
             ]
+
+            has_all_invoices = bool(self.env["account.move"].search_count(search_filter))
         else:
             search_filter = [
                 ("invoice_date_due", "=", invoicing_date),
@@ -349,21 +353,25 @@ class ContractGroup(models.Model):
                     "in",
                     self.active_contract_ids.mapped("product_ids").ids,
                 ),
-                "|",
-                ("payment_state", "not in", ["paid", "not_paid"]),
-                ("state", "=", "cancel"), # ----> change double condition to ("state", "!=", "cancel") ?????
-                # self.env["account.move"].search([("invoice_date_due", "=", invoicing_date), ("partner_id", "=", self.partner_id.id), ("move_type", "=", "out_invoice"), ("line_ids.contract_id", "in", self.active_contract_ids.ids), ("state", "!=", "cancel")])
-                # 31551
+                ('state', '!=', 'cancel')
+                #"|",
+                #("payment_state", "not in", ["paid", "not_paid"]),
+                #("state", "=", "cancel"), # ----> change double condition to ("state", "!=", "cancel") ?????
             ]
 
-        existing_invoices = self.env["account.move"].search_count(search_filter)
+            # self.env["account.move"].search([("invoice_date_due", "=", invoicing_date), ("partner_id", "=", self.partner_id.id), ("move_type", "=", "out_invoice"), ("line_ids.contract_id", "in", self.active_contract_ids.ids), ("state", "!=", "cancel")])
+            # 31551
+
+            open_invoices = self.env["account.move"].search(search_filter)
+
+            has_all_invoices = len(self.active_contract_ids - open_invoices.line_ids.contract_id) == 0
 
         is_suspended = (
             self.invoice_suspended_until
             and self.invoice_suspended_until > invoicing_date
         )
 
-        return bool(existing_invoices) or is_suspended
+        return has_all_invoices or is_suspended
 
     def _process_invoice_generation(self, invoicer, invoicing_date, contract=None):
         self.ensure_one()

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -343,7 +343,7 @@ class ContractGroup(models.Model):
                 ("invoice_date_due", "=", invoicing_date),
                 ("partner_id", "=", self.partner_id.id),
                 ("move_type", "=", "out_invoice"),
-                ("line_ids.contract_id", "in", self.active_contract_ids.ids),
+                ("line_ids.contract_id", "in", self.active_contract_ids.ids), # ----> should check that it found count == active_contracts.count ? if not if a single other active contract has an invoice it will not generate or update the amount
                 (
                     "line_ids.product_id",
                     "in",
@@ -351,7 +351,9 @@ class ContractGroup(models.Model):
                 ),
                 "|",
                 ("payment_state", "not in", ["paid", "not_paid"]),
-                ("state", "=", "cancel"),
+                ("state", "=", "cancel"), # ----> change double condition to ("state", "!=", "cancel") ?????
+                # self.env["account.move"].search([("invoice_date_due", "=", invoicing_date), ("partner_id", "=", self.partner_id.id), ("move_type", "=", "out_invoice"), ("line_ids.contract_id", "in", self.active_contract_ids.ids), ("state", "!=", "cancel")])
+                # 31551
             ]
 
         existing_invoices = self.env["account.move"].search_count(search_filter)

--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -359,7 +359,8 @@ class ContractGroup(models.Model):
 
             open_invoices = self.env["account.move"].search(search_filter)
 
-            has_all_invoices = len(self.active_contract_ids - open_invoices.line_ids.contract_id) == 0
+            has_all_invoices = len(self.active_contract_ids -
+                                   open_invoices.mapped("line_ids.contract_id")) == 0
 
         is_suspended = (
             self.invoice_suspended_until

--- a/recurring_contract/wizards/recurring_invoicer_wizard.py
+++ b/recurring_contract/wizards/recurring_invoicer_wizard.py
@@ -43,6 +43,8 @@ class InvoicerWizard(models.TransientModel):
         group_ids = [r[0] for r in self.env.cr.fetchall()]
         groups = self.env["recurring.contract.group"].browse(group_ids)
 
+        groups = groups[1]
+
         # Add a job for all groups and start the job when all jobs are created.
         invoicer = groups.generate_invoices()
         res_id = False

--- a/recurring_contract/wizards/recurring_invoicer_wizard.py
+++ b/recurring_contract/wizards/recurring_invoicer_wizard.py
@@ -43,7 +43,7 @@ class InvoicerWizard(models.TransientModel):
         group_ids = [r[0] for r in self.env.cr.fetchall()]
         groups = self.env["recurring.contract.group"].browse(group_ids)
 
-        # TOTO : REVERT DUMMY CHANGES BEFORE PUBLISHING PR
+        # TODO (NiP): REVERT DUMMY CHANGES BEFORE PUBLISHING PR
         #groups = self.env["recurring.contract.group"].browse(20772)
         groups = groups[1]
 

--- a/recurring_contract/wizards/recurring_invoicer_wizard.py
+++ b/recurring_contract/wizards/recurring_invoicer_wizard.py
@@ -43,8 +43,8 @@ class InvoicerWizard(models.TransientModel):
         group_ids = [r[0] for r in self.env.cr.fetchall()]
         groups = self.env["recurring.contract.group"].browse(group_ids)
 
+        # TOTO : REVERT DUMMY CHANGES BEFORE PUBLISHING PR
         #groups = self.env["recurring.contract.group"].browse(20772)
-
         groups = groups[1]
 
         # Add a job for all groups and start the job when all jobs are created.

--- a/recurring_contract/wizards/recurring_invoicer_wizard.py
+++ b/recurring_contract/wizards/recurring_invoicer_wizard.py
@@ -43,6 +43,8 @@ class InvoicerWizard(models.TransientModel):
         group_ids = [r[0] for r in self.env.cr.fetchall()]
         groups = self.env["recurring.contract.group"].browse(group_ids)
 
+        #groups = self.env["recurring.contract.group"].browse(20772)
+
         groups = groups[1]
 
         # Add a job for all groups and start the job when all jobs are created.

--- a/recurring_contract/wizards/recurring_invoicer_wizard.py
+++ b/recurring_contract/wizards/recurring_invoicer_wizard.py
@@ -43,10 +43,6 @@ class InvoicerWizard(models.TransientModel):
         group_ids = [r[0] for r in self.env.cr.fetchall()]
         groups = self.env["recurring.contract.group"].browse(group_ids)
 
-        # TODO (NiP): REVERT DUMMY CHANGES BEFORE PUBLISHING PR
-        #groups = self.env["recurring.contract.group"].browse(20772)
-        groups = groups[1]
-
         # Add a job for all groups and start the job when all jobs are created.
         invoicer = groups.generate_invoices()
         res_id = False


### PR DESCRIPTION
# Description
It looks like with the changes we made in this [PR](https://github.com/CompassionCH/compassion-accounting/pull/239) we introduced a new bug. When the CRON to generate invoices runs, dupplicate invoices for an already paid invoice are now generated.

# Technical Aspects
The issue comes from the `_should_skip_invoice_generation` for the case when we don't pass a specific contract. In that case the check would not find `existing_invoices` which returned `False`, and new invoices would be generated.

We changed the logic a bit, so we fetch all open invoices for the due date of that group, and if all active contracts are covered by those invoices then we don't need to generate new ones.