### PR TITLE
T1863 - Cannot create sponsorship for new partner (2/2)

### DIFF
--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -123,6 +123,7 @@ class RecurringContract(models.Model):
     )
     nb_invoices = fields.Integer(compute="_compute_invoices")
     activation_date = fields.Datetime(readonly=True, copy=False)
+
     company_id = fields.Many2one(
         "res.company",
         "Company",
@@ -407,9 +408,11 @@ class RecurringContract(models.Model):
         else:
             self.group_id = False
 
-        # Update the company value based on the partner.country_id
-        # as there is no value for partner.company_id
-        if self.partner_id.country_id:
+        # Update the company value based on the partner.company_id
+        # If there is none, update it based on partner.country_id
+        if self.partner_id.company_id:
+            self.company_id = self.partner_id.company_id
+        elif self.partner_id.country_id:
             company_ids = self.env["res.company"].search(
                 [("partner_id.country_id", "=", self.partner_id.country_id.id)], limit=1
             )

--- a/recurring_contract/models/recurring_contract.py
+++ b/recurring_contract/models/recurring_contract.py
@@ -123,7 +123,6 @@ class RecurringContract(models.Model):
     )
     nb_invoices = fields.Integer(compute="_compute_invoices")
     activation_date = fields.Datetime(readonly=True, copy=False)
-
     company_id = fields.Many2one(
         "res.company",
         "Company",


### PR DESCRIPTION
* follow-up of https://github.com/CompassionCH/compassion-switzerland/pull/1667

# Misc
This kind of reverts the changed made in [this commit](https://github.com/CompassionCH/compassion-accounting/commit/f9b8596e009d108b27076ef4af12ac4c7d4470f5#diff-500c6542cc282ab0ec51b0f15d7c80346f74288f7904b32ffa42f7ddc7409450R375) since it will probably never go to the second case (where we fetch the `company_id` from the `country_id`). 

I kept it just in case but I'm not exactly sure why the behavior was changed in the commit. 