### PR TITLE
T2860 - FIX invoice loop range and skip cancelled invoices on Odoo 18

### DIFF
--- a/recurring_contract/models/contract_group.py
+++ b/recurring_contract/models/contract_group.py
@@ -384,6 +384,7 @@ class ContractGroup(models.Model):
                 ("invoice_date", "=", invoicing_date),
                 ("partner_id", "=", self.partner_id.id),
                 ("move_type", "=", "out_invoice"),
+                ("state", "not in", ["cancel"]),
                 ("line_ids.contract_id", "in", contracts.ids),
                 ("line_ids.product_id", "in", contracts.mapped("product_ids").ids),
             ]


### PR DESCRIPTION
- Fix off-by-one in _generate_invoices loop range: use advance_billing_months + month_interval - 1 as upper bound so the correct number of invoices is produced for all billing cycle combinations
- Exclude cancelled invoices from _should_skip_invoice_generation so that a cancelled invoice no longer blocks regeneration for the same period
- Expand readme (DESCRIPTION, USAGE, DEVELOP) with billing cycle docs